### PR TITLE
[feat] account RUD API 구현

### DIFF
--- a/src/main/java/com/taste/zip/tastezip/controller/AccountController.java
+++ b/src/main/java/com/taste/zip/tastezip/controller/AccountController.java
@@ -1,0 +1,46 @@
+package com.taste.zip.tastezip.controller;
+
+import com.taste.zip.tastezip.auth.TokenDetail;
+import com.taste.zip.tastezip.auth.annotation.AccessToken;
+import com.taste.zip.tastezip.dto.AccountDetailResponse;
+import com.taste.zip.tastezip.service.AccountService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.MediaType;
+import org.springframework.http.ProblemDetail;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+public class AccountController {
+
+    private final AccountService accountService;
+
+    @Operation(summary = "내 정보 확인")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", useReturnTypeSchema = true),
+        @ApiResponse(responseCode = "400", description = "토큰이 만료/변조/비유효 할 때",
+            content = { @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = ProblemDetail.class)) }),
+        @ApiResponse(responseCode = "401", description = "Authorization Header를 입력하지 않거나 Bearer로 시작하지 않을 때",
+            content = { @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = ProblemDetail.class)) }),
+        @ApiResponse(responseCode = "404", description = "토큰 정보에 해당하는 유저가 존재하지 않을 경우",
+            content = { @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = ProblemDetail.class)) })
+    })
+    @GetMapping("/account")
+    public ResponseEntity<AccountDetailResponse> findMyAccount(@Parameter(hidden = true) @AccessToken TokenDetail tokenDetail) {
+        final AccountDetailResponse response = accountService.findMyAccount(tokenDetail);
+
+        return new ResponseEntity<>(response, HttpStatus.OK);
+    }
+}

--- a/src/main/java/com/taste/zip/tastezip/controller/AccountController.java
+++ b/src/main/java/com/taste/zip/tastezip/controller/AccountController.java
@@ -19,6 +19,7 @@ import org.springframework.http.HttpStatusCode;
 import org.springframework.http.MediaType;
 import org.springframework.http.ProblemDetail;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -66,6 +67,22 @@ public class AccountController {
     ) {
         final Account account = accountService.updateMyAccount(request, tokenDetail);
 
+        return new ResponseEntity<>(account, HttpStatus.CREATED);
+    }
+
+    @Operation(summary = "내 계정 삭제")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "201", useReturnTypeSchema = true),
+        @ApiResponse(responseCode = "400", description = "토큰이 만료/변조/비유효 할 때",
+            content = { @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = ProblemDetail.class)) }),
+        @ApiResponse(responseCode = "401", description = "Authorization Header를 입력하지 않거나 Bearer로 시작하지 않을 때",
+            content = { @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = ProblemDetail.class)) }),
+        @ApiResponse(responseCode = "404", description = "토큰 정보에 해당하는 유저가 존재하지 않을 경우",
+            content = { @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = ProblemDetail.class)) })
+    })
+    @DeleteMapping("/account")
+    public ResponseEntity<Account> deleteMyAccount(@Parameter(hidden = true) @AccessToken TokenDetail tokenDetail) {
+        final Account account = accountService.deleteMyAccount(tokenDetail);
         return new ResponseEntity<>(account, HttpStatus.CREATED);
     }
 }

--- a/src/main/java/com/taste/zip/tastezip/controller/AccountController.java
+++ b/src/main/java/com/taste/zip/tastezip/controller/AccountController.java
@@ -2,8 +2,10 @@ package com.taste.zip.tastezip.controller;
 
 import com.taste.zip.tastezip.auth.TokenDetail;
 import com.taste.zip.tastezip.auth.annotation.AccessToken;
+import com.taste.zip.tastezip.dto.AccountDeleteResponse;
 import com.taste.zip.tastezip.dto.AccountDetailResponse;
 import com.taste.zip.tastezip.dto.AccountUpdateRequest;
+import com.taste.zip.tastezip.dto.AccountUpdateResponse;
 import com.taste.zip.tastezip.entity.Account;
 import com.taste.zip.tastezip.service.AccountService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -15,7 +17,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.HttpStatusCode;
 import org.springframework.http.MediaType;
 import org.springframework.http.ProblemDetail;
 import org.springframework.http.ResponseEntity;
@@ -61,13 +62,13 @@ public class AccountController {
             content = { @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = ProblemDetail.class)) })
     })
     @PostMapping("/account")
-    public ResponseEntity<Account> updateMyAccount(
+    public ResponseEntity<AccountUpdateResponse> updateMyAccount(
         @Valid @RequestBody AccountUpdateRequest request,
         @Parameter(hidden = true) @AccessToken TokenDetail tokenDetail
     ) {
-        final Account account = accountService.updateMyAccount(request, tokenDetail);
+        final AccountUpdateResponse response = accountService.updateMyAccount(request, tokenDetail);
 
-        return new ResponseEntity<>(account, HttpStatus.CREATED);
+        return new ResponseEntity<>(response, HttpStatus.CREATED);
     }
 
     @Operation(summary = "내 계정 삭제")
@@ -81,8 +82,8 @@ public class AccountController {
             content = { @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = ProblemDetail.class)) })
     })
     @DeleteMapping("/account")
-    public ResponseEntity<Account> deleteMyAccount(@Parameter(hidden = true) @AccessToken TokenDetail tokenDetail) {
-        final Account account = accountService.deleteMyAccount(tokenDetail);
-        return new ResponseEntity<>(account, HttpStatus.CREATED);
+    public ResponseEntity<AccountDeleteResponse> deleteMyAccount(@Parameter(hidden = true) @AccessToken TokenDetail tokenDetail) {
+        final AccountDeleteResponse response = accountService.deleteMyAccount(tokenDetail);
+        return new ResponseEntity<>(response, HttpStatus.CREATED);
     }
 }

--- a/src/main/java/com/taste/zip/tastezip/controller/AccountController.java
+++ b/src/main/java/com/taste/zip/tastezip/controller/AccountController.java
@@ -3,6 +3,8 @@ package com.taste.zip.tastezip.controller;
 import com.taste.zip.tastezip.auth.TokenDetail;
 import com.taste.zip.tastezip.auth.annotation.AccessToken;
 import com.taste.zip.tastezip.dto.AccountDetailResponse;
+import com.taste.zip.tastezip.dto.AccountUpdateRequest;
+import com.taste.zip.tastezip.entity.Account;
 import com.taste.zip.tastezip.service.AccountService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -10,6 +12,7 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
@@ -17,6 +20,8 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ProblemDetail;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -42,5 +47,25 @@ public class AccountController {
         final AccountDetailResponse response = accountService.findMyAccount(tokenDetail);
 
         return new ResponseEntity<>(response, HttpStatus.OK);
+    }
+
+    @Operation(summary = "내 정보 수정")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "201", useReturnTypeSchema = true),
+        @ApiResponse(responseCode = "400", description = "토큰이 만료/변조/비유효 할 때",
+            content = { @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = ProblemDetail.class)) }),
+        @ApiResponse(responseCode = "401", description = "Authorization Header를 입력하지 않거나 Bearer로 시작하지 않을 때",
+            content = { @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = ProblemDetail.class)) }),
+        @ApiResponse(responseCode = "404", description = "토큰 정보에 해당하는 유저가 존재하지 않을 경우",
+            content = { @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = ProblemDetail.class)) })
+    })
+    @PostMapping("/account")
+    public ResponseEntity<Account> updateMyAccount(
+        @Valid @RequestBody AccountUpdateRequest request,
+        @Parameter(hidden = true) @AccessToken TokenDetail tokenDetail
+    ) {
+        final Account account = accountService.updateMyAccount(request, tokenDetail);
+
+        return new ResponseEntity<>(account, HttpStatus.CREATED);
     }
 }

--- a/src/main/java/com/taste/zip/tastezip/controller/AuthController.java
+++ b/src/main/java/com/taste/zip/tastezip/controller/AuthController.java
@@ -48,7 +48,7 @@ public class AuthController {
     public ResponseEntity<?> login(@RequestParam String id) {
         final String token = tokenProvider.createToken(Duration.ofDays(1), Type.ACCESS_TOKEN,
             TokenDetail.builder(Long.valueOf(id)).build());
-        return new ResponseEntity<>(token, HttpStatusCode.valueOf(200));
+        return new ResponseEntity<>(token, HttpStatus.OK);
     }
 
     @Operation(summary = "회원가입 (비인가)")
@@ -62,7 +62,7 @@ public class AuthController {
     @PostMapping("/registration")
     public ResponseEntity<AuthRegistrationResponse> registration(@Valid @RequestBody AuthRegistrationRequest request) {
         final AuthRegistrationResponse response = accountService.register(request);
-        return new ResponseEntity<>(response,HttpStatusCode.valueOf(200));
+        return new ResponseEntity<>(response, HttpStatus.OK);
     }
 
     @Operation(summary = "토큰 정보 확인")
@@ -80,6 +80,6 @@ public class AuthController {
 
         final HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_JSON);
-        return new ResponseEntity<>(parsedToken, headers ,HttpStatusCode.valueOf(200));
+        return new ResponseEntity<>(parsedToken, headers ,HttpStatus.OK);
     }
 }

--- a/src/main/java/com/taste/zip/tastezip/dto/AccountDeleteResponse.java
+++ b/src/main/java/com/taste/zip/tastezip/dto/AccountDeleteResponse.java
@@ -1,0 +1,9 @@
+package com.taste.zip.tastezip.dto;
+
+import com.taste.zip.tastezip.entity.Account;
+
+public record AccountDeleteResponse(
+    Account account
+) {
+
+}

--- a/src/main/java/com/taste/zip/tastezip/dto/AccountDetailResponse.java
+++ b/src/main/java/com/taste/zip/tastezip/dto/AccountDetailResponse.java
@@ -1,0 +1,26 @@
+package com.taste.zip.tastezip.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonIgnoreType;
+import com.taste.zip.tastezip.entity.Account;
+import com.taste.zip.tastezip.entity.AccountConfig;
+import com.taste.zip.tastezip.entity.AccountOAuth;
+import java.util.List;
+import lombok.Builder;
+
+@Builder(builderMethodName = "hiddenBuilder")
+public record AccountDetailResponse(
+    Account account,
+    @JsonIgnoreProperties(value = { "account" })
+    List<AccountOAuth> oauthList,
+    @JsonIgnoreProperties(value = { "account" })
+    List<AccountConfig> configList
+) {
+
+    public static AccountDetailResponseBuilder builder(Account account, List<AccountOAuth> oauthList, List<AccountConfig> configList) {
+        return hiddenBuilder()
+            .account(account)
+            .oauthList(oauthList)
+            .configList(configList);
+    }
+}

--- a/src/main/java/com/taste/zip/tastezip/dto/AccountUpdateRequest.java
+++ b/src/main/java/com/taste/zip/tastezip/dto/AccountUpdateRequest.java
@@ -1,0 +1,15 @@
+package com.taste.zip.tastezip.dto;
+
+import com.taste.zip.tastezip.entity.enumeration.AccountType;
+import jakarta.validation.constraints.NotNull;
+
+public record AccountUpdateRequest(
+    @NotNull(message = "{field.not-null}")
+    String nickname,
+    String bio,
+    String profileImage,
+    @NotNull(message = "{field.not-null}")
+    AccountType type
+) {
+
+}

--- a/src/main/java/com/taste/zip/tastezip/dto/AccountUpdateResponse.java
+++ b/src/main/java/com/taste/zip/tastezip/dto/AccountUpdateResponse.java
@@ -1,0 +1,9 @@
+package com.taste.zip.tastezip.dto;
+
+import com.taste.zip.tastezip.entity.Account;
+
+public record AccountUpdateResponse(
+    Account account
+) {
+
+}

--- a/src/main/java/com/taste/zip/tastezip/dto/AuthRegistrationRequest.java
+++ b/src/main/java/com/taste/zip/tastezip/dto/AuthRegistrationRequest.java
@@ -7,19 +7,19 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 
 public record AuthRegistrationRequest(
-    @NotNull(message = "{account.register.notnull}")
+    @NotNull(message = "{field.not-null}")
     String nickname,
     String bio,
     String profileImage,
-    @NotNull(message = "{account.register.notnull}")
+    @NotNull(message = "{field.not-null}")
     AccountType type,
     @Valid Config config,
     @Valid OAuth oauth
 ) {
     public record OAuth(
-        @NotNull(message = "{account.register.notnull}")
+        @NotNull(message = "{field.not-null}")
         OAuthType type,
-        @NotNull(message = "{account.register.notnull}")
+        @NotNull(message = "{field.not-null}")
         String oauthPk,
         String accessToken,
         String refreshToken,
@@ -35,11 +35,11 @@ public record AuthRegistrationRequest(
      * 필드 이름 잘 맞출 것, 오타 조심!
      */
     public record Config(
-        @NotNull(message = "{account.register.notnull}")
+        @NotNull(message = "{field.not-null}")
         AccountConfigType.Agreement TERM_OF_USE_AGREEMENT,
-        @NotNull(message = "{account.register.notnull}")
+        @NotNull(message = "{field.not-null}")
         AccountConfigType.Agreement TERM_OF_GPS_AGREEMENT,
-        @NotNull(message = "{account.register.notnull}")
+        @NotNull(message = "{field.not-null}")
         AccountConfigType.Agreement MARKETING_MESSAGE_AGREEMENT
     ) {
 

--- a/src/main/java/com/taste/zip/tastezip/dto/AuthRegistrationRequest.java
+++ b/src/main/java/com/taste/zip/tastezip/dto/AuthRegistrationRequest.java
@@ -1,5 +1,6 @@
 package com.taste.zip.tastezip.dto;
 
+import com.taste.zip.tastezip.entity.enumeration.AccountConfigType;
 import com.taste.zip.tastezip.entity.enumeration.AccountType;
 import com.taste.zip.tastezip.entity.enumeration.OAuthType;
 import jakarta.validation.Valid;
@@ -29,13 +30,17 @@ public record AuthRegistrationRequest(
 
     }
 
+    /**
+     * @see com.taste.zip.tastezip.entity.enumeration.AccountConfigType
+     * 필드 이름 잘 맞출 것, 오타 조심!
+     */
     public record Config(
         @NotNull(message = "{account.register.notnull}")
-        Boolean TERM_OF_USE_AGREEMENT,
+        AccountConfigType.Agreement TERM_OF_USE_AGREEMENT,
         @NotNull(message = "{account.register.notnull}")
-        Boolean TERM_OF_GPS_AGREEMENT,
+        AccountConfigType.Agreement TERM_OF_GPS_AGREEMENT,
         @NotNull(message = "{account.register.notnull}")
-        Boolean MARKETING_MESSAGE_AGREEMENT
+        AccountConfigType.Agreement MARKETING_MESSAGE_AGREEMENT
     ) {
 
     }

--- a/src/main/java/com/taste/zip/tastezip/entity/Account.java
+++ b/src/main/java/com/taste/zip/tastezip/entity/Account.java
@@ -1,5 +1,6 @@
 package com.taste.zip.tastezip.entity;
 
+import com.taste.zip.tastezip.dto.AccountUpdateRequest;
 import com.taste.zip.tastezip.entity.enumeration.converter.AccountTypeConverter;
 import com.taste.zip.tastezip.entity.enumeration.AccountType;
 import jakarta.persistence.Column;
@@ -55,5 +56,13 @@ public class Account extends AuditingEntity {
         return hiddenBuilder()
             .nickname(nickname)
             .type(type);
+    }
+
+    public Account update(AccountUpdateRequest request) {
+        this.nickname = request.nickname();
+        this.bio = request.bio();
+        this.profileImage = request.profileImage();
+        this.type = request.type();
+        return this;
     }
 }

--- a/src/main/java/com/taste/zip/tastezip/entity/AccountCafeteriaMapping.java
+++ b/src/main/java/com/taste/zip/tastezip/entity/AccountCafeteriaMapping.java
@@ -33,7 +33,7 @@ public class AccountCafeteriaMapping extends AuditingEntity {
     private AccountCafeteriaMappingType type;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @OnDelete(action = OnDeleteAction.CASCADE)
+    @OnDelete(action = OnDeleteAction.SET_NULL)
     private Account account;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/taste/zip/tastezip/entity/AccountVideoMapping.java
+++ b/src/main/java/com/taste/zip/tastezip/entity/AccountVideoMapping.java
@@ -36,7 +36,7 @@ public class AccountVideoMapping extends AuditingEntity {
     private String score;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @OnDelete(action = OnDeleteAction.CASCADE)
+    @OnDelete(action = OnDeleteAction.SET_NULL)
     private Account account;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/taste/zip/tastezip/entity/AccountYoutube.java
+++ b/src/main/java/com/taste/zip/tastezip/entity/AccountYoutube.java
@@ -29,7 +29,7 @@ public class AccountYoutube extends AuditingEntity {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @OnDelete(action = OnDeleteAction.CASCADE)
+    @OnDelete(action = OnDeleteAction.SET_NULL)
     private Account account;
 
     @Column

--- a/src/main/java/com/taste/zip/tastezip/entity/Comment.java
+++ b/src/main/java/com/taste/zip/tastezip/entity/Comment.java
@@ -29,7 +29,7 @@ public class Comment extends AuditingEntity {
     private String content;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @OnDelete(action = OnDeleteAction.CASCADE)
+    @OnDelete(action = OnDeleteAction.SET_NULL)
     private Account account;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/taste/zip/tastezip/entity/enumeration/AccountConfigType.java
+++ b/src/main/java/com/taste/zip/tastezip/entity/enumeration/AccountConfigType.java
@@ -6,18 +6,24 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum AccountConfigType {
+
     /**
      * 기본 이용 약관 동의 여부
      */
-    TERM_OF_USE_AGREEMENT(Boolean.class),
+    TERM_OF_USE_AGREEMENT(Agreement.class),
     /**
      * 위치 기반 서비스 이용 동의 여부
      */
-    TERM_OF_GPS_AGREEMENT(Boolean.class),
+    TERM_OF_GPS_AGREEMENT(Agreement.class),
     /**
      * 마케팅 정보 수신 동의 여부
      */
-    MARKETING_MESSAGE_AGREEMENT(Boolean.class);
+    MARKETING_MESSAGE_AGREEMENT(Agreement.class);
+
+    public enum Agreement {
+        ACCEPTED,
+        REJECTED
+    }
 
     private final Class<?> valueClassType;
 }

--- a/src/main/java/com/taste/zip/tastezip/repository/AccountConfigRepository.java
+++ b/src/main/java/com/taste/zip/tastezip/repository/AccountConfigRepository.java
@@ -1,8 +1,10 @@
 package com.taste.zip.tastezip.repository;
 
 import com.taste.zip.tastezip.entity.AccountConfig;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface AccountConfigRepository extends JpaRepository<AccountConfig, Long> {
 
+    List<AccountConfig> findAllByAccount_Id(Long accountId);
 }

--- a/src/main/java/com/taste/zip/tastezip/repository/AccountOAuthRepository.java
+++ b/src/main/java/com/taste/zip/tastezip/repository/AccountOAuthRepository.java
@@ -1,10 +1,14 @@
 package com.taste.zip.tastezip.repository;
 
+import com.taste.zip.tastezip.entity.Account;
 import com.taste.zip.tastezip.entity.AccountOAuth;
 import com.taste.zip.tastezip.entity.enumeration.OAuthType;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface AccountOAuthRepository extends JpaRepository<AccountOAuth, Long> {
 
     boolean existsByTypeAndOauthPk(OAuthType type, String oauthPk);
+
+    List<AccountOAuth> findAllByAccount_Id(Long accountId);
 }

--- a/src/main/java/com/taste/zip/tastezip/service/AccountService.java
+++ b/src/main/java/com/taste/zip/tastezip/service/AccountService.java
@@ -4,10 +4,12 @@ import com.taste.zip.tastezip.auth.TokenDetail;
 import com.taste.zip.tastezip.auth.TokenProvider;
 import com.taste.zip.tastezip.auth.TokenProvider.Type;
 import com.taste.zip.tastezip.auth.annotation.AccessTokenResolver;
+import com.taste.zip.tastezip.dto.AccountDeleteResponse;
 import com.taste.zip.tastezip.dto.AccountDetailResponse;
 import com.taste.zip.tastezip.dto.AccountUpdateRequest;
 import com.taste.zip.tastezip.dto.AuthRegistrationRequest;
 import com.taste.zip.tastezip.dto.AuthRegistrationResponse;
+import com.taste.zip.tastezip.dto.AccountUpdateResponse;
 import com.taste.zip.tastezip.entity.Account;
 import com.taste.zip.tastezip.entity.AccountConfig;
 import com.taste.zip.tastezip.entity.AccountOAuth;
@@ -26,11 +28,9 @@ import java.time.Duration;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.MessageSource;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.HttpStatusCode;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.client.HttpClientErrorException;
@@ -174,7 +174,7 @@ public class AccountService {
     }
 
     @Transactional
-    public Account updateMyAccount(AccountUpdateRequest request, TokenDetail tokenDetail) {
+    public AccountUpdateResponse updateMyAccount(AccountUpdateRequest request, TokenDetail tokenDetail) {
         final Optional<Account> account = accountRepository.findById(tokenDetail.userId());
 
         if (account.isEmpty()) {
@@ -183,7 +183,7 @@ public class AccountService {
             throw new HttpClientErrorException(HttpStatus.NOT_FOUND, errorMessage);
         }
 
-        return account.get().update(request);
+        return new AccountUpdateResponse(account.get().update(request));
     }
 
     /**
@@ -193,7 +193,7 @@ public class AccountService {
      * @exception Throw HttpClientErrorException(400 error) when given token is weired
      */
     @Transactional
-    public Account deleteMyAccount(TokenDetail tokenDetail) {
+    public AccountDeleteResponse deleteMyAccount(TokenDetail tokenDetail) {
         final Optional<Account> account = accountRepository.findById(tokenDetail.userId());
 
         if (account.isEmpty()) {
@@ -204,6 +204,6 @@ public class AccountService {
 
         accountRepository.delete(account.get());
 
-        return account.get();
+        return new AccountDeleteResponse(account.get());
     }
 }

--- a/src/main/java/com/taste/zip/tastezip/service/AccountService.java
+++ b/src/main/java/com/taste/zip/tastezip/service/AccountService.java
@@ -185,4 +185,25 @@ public class AccountService {
 
         return account.get().update(request);
     }
+
+    /**
+     * Delete user entity and other entities related
+     * @exception Throw 404 error when account of tokenDetial doesn't exist
+     * @exception Throw HttpClientErrorException(401 error) when Authorization header is empty or not start with 'Bearer'
+     * @exception Throw HttpClientErrorException(400 error) when given token is weired
+     */
+    @Transactional
+    public Account deleteMyAccount(TokenDetail tokenDetail) {
+        final Optional<Account> account = accountRepository.findById(tokenDetail.userId());
+
+        if (account.isEmpty()) {
+            final String errorMessage = messageSource.getMessage("account.find.not-exist",
+                new Object[]{tokenDetail.userId()}, null);
+            throw new HttpClientErrorException(HttpStatus.NOT_FOUND, errorMessage);
+        }
+
+        accountRepository.delete(account.get());
+
+        return account.get();
+    }
 }

--- a/src/main/java/com/taste/zip/tastezip/service/AccountService.java
+++ b/src/main/java/com/taste/zip/tastezip/service/AccountService.java
@@ -5,6 +5,7 @@ import com.taste.zip.tastezip.auth.TokenProvider;
 import com.taste.zip.tastezip.auth.TokenProvider.Type;
 import com.taste.zip.tastezip.auth.annotation.AccessTokenResolver;
 import com.taste.zip.tastezip.dto.AccountDetailResponse;
+import com.taste.zip.tastezip.dto.AccountUpdateRequest;
 import com.taste.zip.tastezip.dto.AuthRegistrationRequest;
 import com.taste.zip.tastezip.dto.AuthRegistrationResponse;
 import com.taste.zip.tastezip.entity.Account;
@@ -170,5 +171,18 @@ public class AccountService {
                 accountConfigList
             )
             .build();
+    }
+
+    @Transactional
+    public Account updateMyAccount(AccountUpdateRequest request, TokenDetail tokenDetail) {
+        final Optional<Account> account = accountRepository.findById(tokenDetail.userId());
+
+        if (account.isEmpty()) {
+            final String errorMessage = messageSource.getMessage("account.find.not-exist",
+                new Object[]{tokenDetail.userId()}, null);
+            throw new HttpClientErrorException(HttpStatus.NOT_FOUND, errorMessage);
+        }
+
+        return account.get().update(request);
     }
 }

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -1,5 +1,9 @@
+#
+# Error message properties
+#
+field.not-null=mandatory field cannot be null
+
 account.find.not-exist=user {0} doesn't exist 
-account.register.notnull=mandatory field cannot be null
 account.register.duplicated-oauth-pk=(type, oauthPk) pair has been already registered
 
 admin.config.no-token-duration=Token expiration time is not configured at server. Go ask administrator


### PR DESCRIPTION
## 1. Describe

- account RUD API 구현

## 2. Changes

- account RUD API 구현
- *회원가입 API AGREEMENT Enum 추가

## 3. Test Image


## 4. Related Issue

- 로컬 환경에서 account_cafeteria_mapping, account_video_mapping, account_youtube, comment의 Foreign Key를 삭제한 후 어플리케이션을 실행해야 Hibernate의 @OnDelete의 변경사항이 적용된다.
  - <img width="600" alt="스크린샷 2024-05-17 오후 6 07 33" src="https://github.com/taste-zzip/taste.zip.server/assets/12531340/a58c5b7f-3928-4b7a-85bf-b8cf09562fd9">
  - <img width="600" alt="스크린샷 2024-05-17 오후 6 10 45" src="https://github.com/taste-zzip/taste.zip.server/assets/12531340/a2110e04-d553-4f37-9850-ad80b7b1acfa">