### PR TITLE
feat: 식당 월드컵 api 구현

### DIFF
--- a/src/main/java/com/taste/zip/tastezip/controller/VideoController.java
+++ b/src/main/java/com/taste/zip/tastezip/controller/VideoController.java
@@ -2,11 +2,7 @@ package com.taste.zip.tastezip.controller;
 
 import com.taste.zip.tastezip.auth.TokenDetail;
 import com.taste.zip.tastezip.auth.annotation.AccessToken;
-import com.taste.zip.tastezip.dto.AccountVideoMappingCreateRequest;
-import com.taste.zip.tastezip.dto.AccountVideoMappingCreateResponse;
-import com.taste.zip.tastezip.dto.AccountVideoMappingDeleteResponse;
-import com.taste.zip.tastezip.dto.VideoDetailResponse;
-import com.taste.zip.tastezip.dto.VideoFeedResponse;
+import com.taste.zip.tastezip.dto.*;
 import com.taste.zip.tastezip.entity.enumeration.AccountVideoMappingType;
 import com.taste.zip.tastezip.service.VideoService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -17,6 +13,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.apache.coyote.Response;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ProblemDetail;
@@ -29,6 +26,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api")
@@ -117,4 +116,24 @@ public class VideoController {
         final VideoDetailResponse response = videoService.findDetail(videoId, tokenDetail);
         return new ResponseEntity<>(response, HttpStatus.OK);
     }
+
+    @Operation(summary = "월드컵 영상 리스트 불러오기")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", useReturnTypeSchema = true),
+            @ApiResponse(responseCode = "400", description = "토큰이 만료/변조/비유효 할 때 / 필수 파라미터를 입력하지 않았을 때",
+                    content = { @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = ProblemDetail.class)) }),
+            @ApiResponse(responseCode = "401", description = "Authorization Header를 입력하지 않거나 Bearer로 시작하지 않을 때",
+                    content = { @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = ProblemDetail.class)) }),
+            @ApiResponse(responseCode = "404", description = "토큰 정보에 해당하는 유저/videoId에 해당하는 영상이 존재하지 않을 경우",
+                    content = { @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = ProblemDetail.class)) })
+    })
+    @GetMapping("/video/worldcup")
+    public ResponseEntity<List<VideoResponse>> getWorldCupVideos(
+            @Parameter(hidden = true) @AccessToken TokenDetail tokenDetail
+    ) {
+        // 16개의 비디오 객체를 반환한다.
+        final List<VideoResponse> responses = videoService.getWorldCupVideos(tokenDetail);
+        return ResponseEntity.ok(responses);
+    }
+
 }


### PR DESCRIPTION
## 1. Describe
식당 월드컵 api 구현

## 2. Changes
16개 video 객체 랜덤 전달
월드컵 우승은 video/user 의 트로피 객체에 해당해서 추가 사항 없음.

## 3. Test Image


## 4. Related Issue
close #